### PR TITLE
Add support for watching code changes & other minor improvements

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,12 +10,9 @@
             "type": "dart",
             "program": "bin/cached_build_runner.dart",
             "args": [
-                "-c",
-                "/Users/jyotirmoypaul/.cached_build_runner_dev",
+                "build",
                 "-p",
-			    "/Users/jyotirmoypaul/Documents/workspace/uni-app",
-                "-t",
-                "-r",
+			    "/Users/mr.paul/Workspace/flutter/cached_build_runner/example",
             ],
             "preLaunchTask": "killRedisServer"
         }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
                 "-p",
 			    "/Users/mr.paul/Workspace/flutter/cached_build_runner/example",
             ],
-            "preLaunchTask": "killRedisServer"
+            // "preLaunchTask": "killRedisServer"
         }
     ],
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-# 0.0.4
+## 0.0.5
+
+- Add support for watching code changes in project directory, and generate code files when needed.
+- Make cached_build_runner similar to build_runner, now **build** & **watch** commands are available.
+- Remove the -t, --generate-test-mock flag, as it was unnecessary.
+- Update code to use native dart regex instead of relying on grep tool.
+
+## 0.0.4
 
 - Minor code changes were done, nothing functionality wise, but addition of better formatting & addition of dartdocs.
 

--- a/README.md
+++ b/README.md
@@ -5,14 +5,22 @@ Cached Build Runner is a Dart package that optimizes the build_runner by caching
 ## Usage
 
 ```bash
-cached_build_runner [options]
+cached_build_runner <command> [arguments]
 ```
 
 ### Usage
+Global options:
+-h, --help    Print this usage information.
+
+Available commands:
+* **build**:  Performs a single build on the specified targets and then exits.
+* **watch**:   Builds the specified targets, watching the file system for updates and rebuilding as appropriate.
+
+Available arguments:
 * -h, --help: Print out usage instructions.
 * -q, --quiet: Disables printing out logs during the build.
-* -t, --generate-test-mock: Generates mocks for test files. If this flag is not provided, mock generations are skipped.
 * -r, --redis: Use Redis database if installed on the system. Using Redis allows multiple instance access and is ideal for usage in pipelines. The default implementation uses a file system storage (Hive), which is ideal for usage in local systems.
+
 * -c, --cache-directory: Provide the directory where this tool can keep the caches.
 * -p, --project-directory: Provide the directory of the project.
 

--- a/bin/cached_build_runner.dart
+++ b/bin/cached_build_runner.dart
@@ -1,107 +1,15 @@
-import 'dart:io';
-
-import 'package:args/args.dart';
-import 'package:cached_build_runner/cached_build_runner.dart'
-    as cached_build_runner;
-import 'package:cached_build_runner/database/database_service.dart';
-import 'package:cached_build_runner/utils/log.dart';
-import 'package:cached_build_runner/utils/utils.dart';
-
-/// parser argument flags & options
-const help = 'help';
-const quiet = 'quiet';
-const useRedis = 'redis';
-const generateTestMocks = 'generate-test-mock';
-const cacheDirectory = 'cache-directory';
-const projectDirectory = 'project-directory';
+import 'package:args/command_runner.dart';
+import 'package:cached_build_runner/commands/build_command.dart';
+import 'package:cached_build_runner/commands/watch_command.dart';
 
 Future<void> main(List<String> arguments) async {
-  /// parse args
-  _parseArgs(arguments);
+  const commandName = 'cached_build_runner';
+  const commandDescription =
+      'Optimizes the build_runner by caching generated codes for non changed .dart files';
 
-  /// let's make the appCacheDirectory if not existing already
-  Directory(Utils.appCacheDirectory).createSync(recursive: true);
+  final runner = CommandRunner(commandName, commandDescription)
+    ..addCommand(BuildCommand())
+    ..addCommand(WatchCommand());
 
-  /// init package name of project
-  Utils.initAppPackageName();
-
-  /// initialize the database
-  final databaseService = Utils.isRedisUsed
-      ? RedisDatabaseService()
-      : HiveDatabaseService(Utils.appCacheDirectory);
-  await databaseService.init();
-
-  /// let's initiate the build
-  final buildCache = cached_build_runner.CachedBuildRunner(databaseService);
-  await buildCache.build();
-}
-
-void _parseArgs(List<String> args) {
-  final parser = ArgParser()
-    ..addFlag(help,
-        abbr: 'h', help: 'Print out usage instructions.', negatable: false)
-    ..addFlag(
-      quiet,
-      abbr: 'q',
-      help: 'Disables printing out logs during build.',
-      negatable: false,
-    )
-    ..addFlag(
-      generateTestMocks,
-      abbr: 't',
-      help:
-          'Generates mocks for test files, if this flag is not provided mock generations are skipped.',
-      negatable: false,
-    )
-    ..addFlag(
-      useRedis,
-      abbr: 'r',
-      help:
-          'Use redis database, if installed on the system. Using redis allows multiple instance access. Ideal for usage in pipelines. Default implementation uses a file system storage (hive), which is idea for usage in local systems.',
-      negatable: false,
-    )
-    ..addSeparator('')
-    ..addOption(
-      cacheDirectory,
-      abbr: 'c',
-      help: 'Provide the directory where this tool can keep the caches.',
-    )
-    ..addOption(
-      projectDirectory,
-      abbr: 'p',
-      help: 'Provide the directory of the project.',
-    );
-
-  final result = parser.parse(args);
-
-  if (result.wasParsed(help)) {
-    Logger.i('''
-cached_build_runner: Optimizes the build_runner by caching generated codes for non changed .dart files.
-
-${parser.usage}
-''');
-    exit(0);
-  }
-
-  if (result.wasParsed(cacheDirectory)) {
-    Utils.appCacheDirectory = result[cacheDirectory];
-  } else {
-    Utils.appCacheDirectory = Utils.getDefaultCacheDirectory();
-    Logger.i(
-      "As no '$cacheDirectory' was specified, using the default directory: ${Utils.appCacheDirectory}",
-    );
-  }
-
-  if (result.wasParsed(projectDirectory)) {
-    Utils.projectDirectory = result[projectDirectory];
-  } else {
-    Utils.projectDirectory = Utils.getDefaultProjectDirectory();
-    Logger.i(
-      "As no '$projectDirectory' was specified, using the current directory: ${Utils.projectDirectory}",
-    );
-  }
-
-  Utils.isVerbose = !result.wasParsed(quiet);
-  Utils.generateTestMocks = result.wasParsed(generateTestMocks);
-  Utils.isRedisUsed = result.wasParsed(useRedis);
+  runner.run(arguments);
 }

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,0 +1,47 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+**/doc/api/
+**/ios/Flutter/.last_build_id
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+.pub-cache/
+.pub/
+/build/
+
+# Symbolication related
+app.*.symbols
+
+# Obfuscation related
+app.*.map.json
+
+# Android Studio will place build artifacts here
+/android/app/debug
+/android/app/profile
+/android/app/release
+
+# All generated files
+*.g.dart

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,2 @@
+# example
+An example Flutter project to demonstrate the usage of cached_build_runner.

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,0 +1,29 @@
+# This file configures the analyzer, which statically analyzes Dart code to
+# check for errors, warnings, and lints.
+#
+# The issues identified by the analyzer are surfaced in the UI of Dart-enabled
+# IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
+# invoked from the command line by running `flutter analyze`.
+
+# The following line activates a set of recommended lints for Flutter apps,
+# packages, and plugins designed to encourage good coding practices.
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  # The lint rules applied to this project can be customized in the
+  # section below to disable rules from the `package:flutter_lints/flutter.yaml`
+  # included above or to enable additional rules. A list of all available lints
+  # and their documentation is published at
+  # https://dart-lang.github.io/linter/lints/index.html.
+  #
+  # Instead of disabling a lint rule for the entire project in the
+  # section below, it can also be suppressed for a single line of code
+  # or a specific dart file by using the `// ignore: name_of_lint` and
+  # `// ignore_for_file: name_of_lint` syntax on the line or in the file
+  # producing the lint.
+  rules:
+    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
+    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+
+# Additional information about this file can be found at
+# https://dart.dev/guides/language/analysis-options

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,0 +1,75 @@
+import 'package:example/models/counter_model.dart';
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  // This widget is the root of your application.
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Flutter Demo',
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+    );
+  }
+}
+
+class MyHomePage extends StatefulWidget {
+  const MyHomePage({super.key, required this.title});
+
+  final String title;
+
+  @override
+  State<MyHomePage> createState() => _MyHomePageState();
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+  final _counterModel = CounterModel(
+    description: 'Model which can keep a count.',
+  );
+
+  void _incrementCounter() {
+    setState(() {
+      _counterModel.count++;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.title),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            const Text(
+              'You have pushed the button this many times:',
+            ),
+            Text(
+              '${_counterModel.count}',
+              style: Theme.of(context).textTheme.headlineMedium,
+            ),
+            Text(
+              '${_counterModel.toJson()}',
+              style: Theme.of(context).textTheme.headlineMedium,
+            ),
+          ],
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _incrementCounter,
+        tooltip: 'Increment',
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/example/lib/models/counter_model.dart
+++ b/example/lib/models/counter_model.dart
@@ -1,0 +1,19 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'counter_model.g.dart';
+
+@JsonSerializable()
+class CounterModel {
+  int count;
+  String? description;
+
+  CounterModel({
+    this.count = 0,
+    this.description,
+  });
+
+  factory CounterModel.fromJson(Map<String, dynamic> json) =>
+      _$CounterModelFromJson(json);
+
+  Map<String, dynamic> toJson() => _$CounterModelToJson(this);
+}

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,0 +1,32 @@
+name: example
+description: An example Flutter project to demonstrate the usage of cached_build_runner.
+
+publish_to: 'none' 
+
+
+version: 1.0.0+1
+
+environment:
+  sdk: '>=2.19.2 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.2
+  json_serializable: ^6.6.1
+  json_annotation: ^4.8.0
+  sync: ^0.3.0
+  
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  build_runner: ^2.3.3
+  cached_build_runner:
+    path: ../
+
+  flutter_lints: ^2.0.0
+
+flutter:
+  uses-material-design: true
+

--- a/lib/args/args_parser.dart
+++ b/lib/args/args_parser.dart
@@ -1,0 +1,74 @@
+import 'package:args/args.dart';
+
+import '../utils/log.dart';
+import '../utils/utils.dart';
+import 'args_utils.dart';
+
+class ArgumentParser {
+  final ArgParser _argParser;
+
+  ArgumentParser(this._argParser) {
+    _addFlagAndOption();
+  }
+
+  ArgParser _addFlagAndOption() {
+    return _argParser
+      ..addFlag(
+        ArgsUtils.quiet,
+        abbr: 'q',
+        help: 'Disables printing out logs during build.',
+        negatable: false,
+      )
+      ..addFlag(
+        ArgsUtils.useRedis,
+        abbr: 'r',
+        help:
+            'Use redis database, if installed on the system. Using redis allows multiple instance access. Ideal for usage in pipelines. Default implementation uses a file system storage (hive), which is idea for usage in local systems.',
+        negatable: false,
+      )
+      ..addSeparator('')
+      ..addOption(
+        ArgsUtils.cacheDirectory,
+        abbr: 'c',
+        help: 'Provide the directory where this tool can keep the caches.',
+      )
+      ..addOption(
+        ArgsUtils.projectDirectory,
+        abbr: 'p',
+        help: 'Provide the directory of the project.',
+      );
+  }
+
+  void parseArgs(Iterable<String>? arguments) {
+    if (arguments == null) return;
+
+    /// parse all args
+    final result = _argParser.parse(arguments);
+
+    /// cache directory
+    if (result.wasParsed(ArgsUtils.cacheDirectory)) {
+      Utils.appCacheDirectory = result[ArgsUtils.cacheDirectory];
+    } else {
+      Utils.appCacheDirectory = Utils.getDefaultCacheDirectory();
+      Logger.i(
+        "As no '${ArgsUtils.cacheDirectory}' was specified, using the default directory: ${Utils.appCacheDirectory}",
+      );
+    }
+
+    /// project directory
+    if (result.wasParsed(ArgsUtils.projectDirectory)) {
+      Utils.projectDirectory = result[ArgsUtils.projectDirectory];
+    } else {
+      Utils.projectDirectory = Utils.getDefaultProjectDirectory();
+      Logger.i(
+        "As no '${ArgsUtils.projectDirectory}' was specified, using the current directory: ${Utils.projectDirectory}",
+      );
+    }
+
+    /// quiet
+    Utils.isVerbose = !result.wasParsed(ArgsUtils.quiet);
+
+    /// use redis
+    Utils.isRedisUsed = result.wasParsed(ArgsUtils.useRedis);
+  }
+}

--- a/lib/args/args_utils.dart
+++ b/lib/args/args_utils.dart
@@ -1,0 +1,11 @@
+abstract class ArgsUtils {
+  /// commands
+  static const watch = 'watch';
+  static const build = 'build';
+
+  /// argument flags & options
+  static const quiet = 'quiet';
+  static const useRedis = 'redis';
+  static const cacheDirectory = 'cache-directory';
+  static const projectDirectory = 'project-directory';
+}

--- a/lib/commands/build_command.dart
+++ b/lib/commands/build_command.dart
@@ -1,0 +1,32 @@
+import 'dart:async';
+
+import 'package:args/command_runner.dart';
+import 'package:cached_build_runner/commands/initializer.dart';
+import '../args/args_parser.dart';
+import '../args/args_utils.dart';
+
+class BuildCommand extends Command {
+  late final ArgumentParser _argumentParser;
+  final Initializer _initializer;
+
+  BuildCommand() : _initializer = Initializer() {
+    _argumentParser = ArgumentParser(argParser);
+  }
+
+  @override
+  String get description =>
+      'Performs a single build on the specified targets and then exits.';
+
+  @override
+  String get name => ArgsUtils.build;
+
+  @override
+  FutureOr? run() async {
+    /// parse args for the command
+    _argumentParser.parseArgs(argResults?.arguments);
+
+    /// let's get the cachedBuildRunner and execute the build
+    final cachedBuildRunner = await _initializer.init();
+    return cachedBuildRunner.build();
+  }
+}

--- a/lib/commands/initializer.dart
+++ b/lib/commands/initializer.dart
@@ -1,0 +1,26 @@
+import 'dart:io';
+
+import '../cached_build_runner.dart';
+import '../database/database_service.dart';
+import '../utils/utils.dart';
+
+/// This class configures the CachedBuildRunner as per the arguments parsed.
+/// And also initializes any variables, or create cache directory if non-existing.
+class Initializer {
+  Future<CachedBuildRunner> init() async {
+    /// let's make the appCacheDirectory if not existing already
+    Directory(Utils.appCacheDirectory).createSync(recursive: true);
+
+    /// init package name of project
+    Utils.initAppPackageName();
+
+    /// initialize the database
+    final databaseService = Utils.isRedisUsed
+        ? RedisDatabaseService()
+        : HiveDatabaseService(Utils.appCacheDirectory);
+    await databaseService.init();
+
+    /// let's initiate the build
+    return CachedBuildRunner(databaseService);
+  }
+}

--- a/lib/commands/watch_command.dart
+++ b/lib/commands/watch_command.dart
@@ -1,0 +1,33 @@
+import 'dart:async';
+
+import 'package:args/command_runner.dart';
+import 'package:cached_build_runner/commands/initializer.dart';
+import '../args/args_utils.dart';
+
+import '../args/args_parser.dart';
+
+class WatchCommand extends Command {
+  late final ArgumentParser _argumentParser;
+  final Initializer _initializer;
+
+  WatchCommand() : _initializer = Initializer() {
+    _argumentParser = ArgumentParser(argParser);
+  }
+
+  @override
+  String get description =>
+      'Builds the specified targets, watching the file system for updates and rebuilding as appropriate.';
+
+  @override
+  String get name => ArgsUtils.watch;
+
+  @override
+  FutureOr? run() async {
+    /// parse args for the command
+    _argumentParser.parseArgs(argResults?.arguments);
+
+    /// let's get the cachedBuildRunner and execute the build
+    final cachedBuildRunner = await _initializer.init();
+    return cachedBuildRunner.watch();
+  }
+}

--- a/lib/utils/extension.dart
+++ b/lib/utils/extension.dart
@@ -1,0 +1,20 @@
+import 'dart:io';
+
+extension DirectoryExtn on Directory {
+  Stream<FileSystemEvent> watchDartSourceCodeFiles() {
+    return watch(recursive: true).where(
+      (e) =>
+          e.path.endsWith('.dart') &&
+          !e.path.endsWith('.g.dart') &&
+          !e.path.endsWith('.mocks.dart'),
+    );
+  }
+}
+
+extension FileExtn on File {
+  bool isDartSourceCodeFile() {
+    return path.endsWith('.dart') &&
+        !path.endsWith('.g.dart') &&
+        !path.endsWith('.mocks.dart');
+  }
+}

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -10,7 +10,6 @@ abstract class Utils {
   static String appCacheDirectory = '';
   static String projectDirectory = '';
   static bool isVerbose = true;
-  static bool generateTestMocks = false;
   static bool isRedisUsed = false;
 
   /// Initializes the app package name by reading it from pubspec.yaml.
@@ -34,16 +33,9 @@ abstract class Utils {
     return md5.convert(utf8.encode(value)).toString();
   }
 
-  static final Map<String, String> _hashMap = {};
-
   /// Calculates the MD5 digest of a given file [filePath].
   static String calculateDigestFor(String filePath) {
-    if (_hashMap.containsKey(filePath)) {
-      _hashMap[filePath]!;
-    }
-
-    final hash = md5.convert(File(filePath).readAsBytesSync()).toString();
-    return _hashMap[filePath] = hash;
+    return md5.convert(File(filePath).readAsBytesSync()).toString();
   }
 
   /// Retrieves the file path from the import line [importLine] of a package.
@@ -62,7 +54,8 @@ abstract class Utils {
   static String calculateTestFileDigestFor(List<String> dependencies) {
     if (dependencies.isEmpty) {
       throw Exception(
-          'Dependencies list cannot be empty when invoked to generate digest');
+        'Dependencies list cannot be empty when invoked to generate digest',
+      );
     }
 
     final sb = StringBuffer();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   logger: ^1.1.0
   path: ^1.8.2
   redis: ^3.1.0
+  synchronized: ^3.0.1
 
 dev_dependencies:
   lints: 2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cached_build_runner
 description: Optimizes the build_runner by caching generated codes for non changed .dart files
-version: 0.0.4
+version: 0.0.5
 homepage: https://github.com/jyotirmoy-paul/cached_build_runner
 maintainer: Jyotirmoy Paul (@jyotirmoy-paul)
 


### PR DESCRIPTION
- Add support for watching code changes in project directory, and generate code files when needed.
- Make cached_build_runner similar to build_runner, now **build** & **watch** commands are available.
- Remove the -t, --generate-test-mock flag, as it was unnecessary.
- Update code to use native dart regex instead of relying on grep tool.
